### PR TITLE
Remove BCC and Change Mail Owner to Customer

### DIFF
--- a/src/controllers/MainController.php
+++ b/src/controllers/MainController.php
@@ -71,7 +71,7 @@ class MainController extends \craft\web\Controller
 
             $view = $form->getView();
             $mail_owner = $form->getMailOwner();
-            $mail_customer = $form->getMailOwner();
+            $mail_customer = $form->getMailCustomer();
 
             $params = is_array($params) ? $params : json_decode($params, true);
 

--- a/src/controllers/MainController.php
+++ b/src/controllers/MainController.php
@@ -88,8 +88,7 @@ class MainController extends \craft\web\Controller
                     if(!is_null($mail_owner)) {
                         $ownerMail = $mailer->compose($mail_owner, ['model' => $form, 'params' => $params])
                             ->setSubject($form->getSettings()->mail_subject_owner)
-                            ->setTo($form->getSettings()->mail_to)
-                            ->setBcc('submit@dolphiq.nl');
+                            ->setTo($form->getSettings()->mail_to);
 
                         // Save owner mail
                         $this->saveInDb($form, $ownerMail);
@@ -105,7 +104,6 @@ class MainController extends \craft\web\Controller
                         $mailer->compose($mail_customer, ['model' => $form, 'params' => $params])
                             ->setSubject($form->getSettings()->mail_subject_customer)
                             ->setTo($form->email)
-                            ->setBcc('submit@dolphiq.nl')
                             ->send();
                     }
 


### PR DESCRIPTION
- Removed the `setBcc()` that was hardcoded to a dolphiq.nl email address.
- Changed `getMailOwner()` to `getMailCustomer()` for the `$mail_customer` variable.