### PR TITLE
Allow File Attachments

### DIFF
--- a/src/controllers/MainController.php
+++ b/src/controllers/MainController.php
@@ -8,15 +8,16 @@
 
 namespace plugins\dolphiq\form\controllers;
 
+use Yii;
 use Craft;
 use craft\web\View;
-use plugins\dolphiq\form\models\Form;
-use plugins\dolphiq\form\models\log;
-use plugins\dolphiq\form\models\Settings;
-use plugins\dolphiq\form\Plugin;
-use Yii;
+use yii\web\UploadedFile;
 use yii\helpers\FileHelper;
 use yii\mail\MessageInterface;
+use plugins\dolphiq\form\Plugin;
+use plugins\dolphiq\form\models\log;
+use plugins\dolphiq\form\models\Form;
+use plugins\dolphiq\form\models\Settings;
 
 class MainController extends \craft\web\Controller
 {
@@ -75,9 +76,12 @@ class MainController extends \craft\web\Controller
 
             $params = is_array($params) ? $params : json_decode($params, true);
 
-            if ($form->load(Craft::$app->request->post()) && $form->validate()) {
+            // UPLOAD FILES INTO MODEL
+            foreach($form->files as $fileField) {
+                $form->attachment = UploadedFile::getInstance($form, $fileField);
+            }
 
-                /** Validated succesfull. **/
+            if ($form->load(Craft::$app->request->post()) && $form->validate()) {
 
                 // Send mail and return thank you page
                 if(!is_null($mail_owner) || !is_null($mail_customer)) {
@@ -89,6 +93,15 @@ class MainController extends \craft\web\Controller
                         $ownerMail = $mailer->compose($mail_owner, ['model' => $form, 'params' => $params])
                             ->setSubject($form->getSettings()->mail_subject_owner)
                             ->setTo($form->getSettings()->mail_to);
+
+                        foreach ($form->files as $fileField) {
+                            if ($form[$fileField]) {
+                                $ownerMail->attachContent(file_get_contents($form[$fileField]->tempName), [
+                                    'fileName' => $form[$fileField]->name,
+                                    'contentType' => $form[$fileField]->type,
+                                ]);
+                            }
+                        }
 
                         // Save owner mail
                         $this->saveInDb($form, $ownerMail);
@@ -120,7 +133,7 @@ class MainController extends \craft\web\Controller
                 }
             }
 
-            return $this->renderAjax($view, ['model' => $form, 'params' => $params, 'handle' => $handle]);
+            return $this->renderAjax($view, ['model' => $form, 'params' => $params, 'handle' => $handle, 'errors' => $form->getErrors()]);
         }
 
         return null;

--- a/src/models/Form.php
+++ b/src/models/Form.php
@@ -44,6 +44,13 @@ class Form extends Model{
     CONST APPEND_MAIL_CUSTOMER_PART = 'MailCustomer.php';
 
     /**
+     * Model Attributes that will be treated as files.
+     *
+     * @var array
+     */
+    public $files = [];
+
+    /**
      * The name of this form
      * @return string
      */


### PR DESCRIPTION
Allow users to attach files to their forms and email them to the owner.

- Set a `public $files = [];` on the model to define files that should be attached.
- Setup `UploadedFile` object foreach `$files` on model
- Setup `attachContent` on `ownerMail` to get file content and attach it to the email.
- Added `errors` to the response of the form to return submission validation errors. 