### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -21,7 +21,7 @@ class Plugin extends \craft\base\Plugin
         parent::init();
 
         // Custom initialization code goes here...
-        Craft::$app->view->twig->addExtension(new YiiTwigExtension());
+        Craft::$app->view->registerTwigExtension(new YiiTwigExtension());
     }
 
     protected function createSettingsModel()


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.