### PR TITLE
Set allowAnonymous to self::ALLOW_ANONYMOUS_LIVE

### DIFF
--- a/src/controllers/MainController.php
+++ b/src/controllers/MainController.php
@@ -38,7 +38,7 @@ class MainController extends \craft\web\Controller
     /**
      * @inheritdoc
      */
-    protected $allowAnonymous = true;
+    protected $allowAnonymous = self::ALLOW_ANONYMOUS_LIVE;
 
     /**
      * The loaded forms


### PR DESCRIPTION
The form POST was failing unless it originated from a session where the user was signed into a Craft session. Setting allowAnonymous to 1 or to self::ALLOW_ANONYMOUS_LIVE resolves the issue.