### PR TITLE
Fix boolean allowAnonymous error

### DIFF
--- a/src/controllers/MainController.php
+++ b/src/controllers/MainController.php
@@ -55,6 +55,7 @@ class MainController extends \craft\web\Controller
      */
     public function init()
     {
+        $this->allowAnonymous = (is_bool($this->allowAnonymous) ? (int) $this->allowAnonymous : $this->allowAnonymous);
         Yii::$app->view->on(View::EVENT_AFTER_RENDER, function ($e) {
             $e->sender->assetBundles = [];
         });


### PR DESCRIPTION
After updating Craft to v3.2 a boolean is not allowed. In init of parent controller is a check with exception if allowAnonymous is not properly set.