### PR TITLE
Call parent::init() in MainController to fix Craft 3.5 compatibility

### DIFF
--- a/src/controllers/MainController.php
+++ b/src/controllers/MainController.php
@@ -55,6 +55,8 @@ class MainController extends \craft\web\Controller
      */
     public function init()
     {
+        parent::init();
+        
         $this->allowAnonymous = (is_bool($this->allowAnonymous) ? (int) $this->allowAnonymous : $this->allowAnonymous);
         Yii::$app->view->on(View::EVENT_AFTER_RENDER, function ($e) {
             $e->sender->assetBundles = [];


### PR DESCRIPTION
See https://github.com/craftcms/cms/issues/6437#issuecomment-663083678 for details.
Fixes #24